### PR TITLE
feat: payment page

### DIFF
--- a/src/app/(booking-flow)/contact/page.tsx
+++ b/src/app/(booking-flow)/contact/page.tsx
@@ -21,7 +21,7 @@ export default function ContactForm() {
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
-      className="bg-white rounded-xl border border-gray-30 p-4 md:py-12 md:px-15 flex flex-col gap-4 w-full "
+      className="bg-white rounded-xl border border-gray-30 p-4 md:py-12 md:px-15 flex flex-col gap-4 w-full"
     >
       <h2 className="text-lg font-bold">Enter your details below</h2>
       <TextInput

--- a/src/app/(booking-flow)/layout.tsx
+++ b/src/app/(booking-flow)/layout.tsx
@@ -16,6 +16,11 @@ export default function FormLayout({
       email: "",
       phone: "",
       reasonForVisit: "",
+      cardNumber: "",
+      expiryDate: "",
+      cvv: "",
+      billingZipCode: "",
+      cancelationPolicy: false,
     },
   });
 

--- a/src/app/(booking-flow)/layout.tsx
+++ b/src/app/(booking-flow)/layout.tsx
@@ -28,11 +28,9 @@ export default function FormLayout({
     <FormProvider {...methods}>
       <div className="flex flex-col gap-4 items-center justify-center lg:justify-start bg-gray-20 p-4 lg:py-15 lg:px-30 min-h-screen">
         <h1 className="text-lg font-bold lg:hidden">Book appointment</h1>
-        <div className="w-full flex max-w-6xl">
-          <div className="flex flex-col gap-4 lg:flex-row md:items-center lg:items-start justify-between w-full">
-            <SpaInfoCard spaCenter={mockSpaCenter} />
-            <div className="w-full pb-26">{children}</div>
-          </div>
+        <div className="flex flex-col gap-4 lg:flex-row md:items-center lg:items-start justify-between w-full max-w-6xl">
+          <SpaInfoCard spaCenter={mockSpaCenter} />
+          <div className="w-full pb-26">{children}</div>
         </div>
       </div>
     </FormProvider>

--- a/src/app/(booking-flow)/payment/page.tsx
+++ b/src/app/(booking-flow)/payment/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+import { useFormContext } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { TextInput } from "@/components/TextInput";
+import { Button } from "@/components/Button";
+import { BottomBar } from "@/components/BottomBar";
+
+export default function PaymentForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useFormContext();
+  const router = useRouter();
+
+  const onSubmit = () => {
+    router.push("/confirmation");
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="bg-white rounded-xl border border-gray-30 p-4 md:py-12 md:px-15 flex flex-col gap-6 w-full"
+    >
+      <div className="flex flex-col gap-6">
+        <h2 className="text-lg font-bold">Secure your appointment by card</h2>
+        <p className="text-description">
+          A credit or debit card is required to book your appointment.
+        </p>
+        <div className="flex flex-col gap-4">
+          <TextInput
+            label="Card information"
+            {...register("cardNumber", { required: "Card number is required" })}
+            placeholder="1234 1234 1234 1234"
+            error={errors.cardNumber?.message?.toString()}
+          />
+          <div className="flex gap-4 w-full justify-between">
+            <TextInput
+              showLabel={false}
+              label="Expiry date"
+              {...register("expiryDate", {
+                required: "Expiry date is required",
+              })}
+              placeholder="MM/YY"
+              error={errors.expiryDate?.message?.toString()}
+            />
+            <TextInput
+              showLabel={false}
+              label="CVV"
+              {...register("cvv", { required: "CVV is required" })}
+              placeholder="CVV"
+              error={errors.cvv?.message?.toString()}
+            />
+          </div>
+        </div>
+        <TextInput
+          showLabel={false}
+          label="Billing zip code"
+          {...register("billingZipCode", {
+            required: "Billing zip code is required",
+          })}
+          placeholder="Billing zip code"
+          error={errors.billingZipCode?.message?.toString()}
+        />
+        <div className="flex items-start gap-2 relative">
+          <input
+            type="checkbox"
+            className="mt-1"
+            id="cancelationPolicy"
+            {...register("cancelationPolicy", {
+              required: "Please agree to the cancelation policy",
+            })}
+          />
+          <label
+            className="text-description text-sm"
+            htmlFor="cancelationPolicy"
+          >
+            We ask that you please reschedule or cancel at least 24 hours before
+            the beginning of your appointment or you may be charged a
+            cancellation fee of $50. In the event of emergency, contact us
+            directly. Your card will held in case of late cancellation and for
+            future purchases. It will not be charged now.
+          </label>
+          {errors?.cancelationPolicy?.message && (
+            <p className="text-red-600 text-sm text-right absolute -bottom-4 left-0">
+              {errors.cancelationPolicy.message.toString()}
+            </p>
+          )}
+        </div>
+      </div>
+      <hr className="border-gray-30" />
+      <div className="w-full">
+        <Button type="submit" label="Book appointment" fullWidth />
+      </div>
+      <div className="hidden md:block">
+        <BottomBar>
+          <div className="w-full flex justify-end">
+            <Button type="submit" label="Continue" />
+          </div>
+        </BottomBar>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(booking-flow)/payment/page.tsx
+++ b/src/app/(booking-flow)/payment/page.tsx
@@ -18,87 +18,98 @@ export default function PaymentForm() {
   };
 
   return (
-    <form
-      onSubmit={handleSubmit(onSubmit)}
-      className="bg-white rounded-xl border border-gray-30 p-4 md:py-12 md:px-15 flex flex-col gap-6 w-full"
-    >
-      <div className="flex flex-col gap-6">
-        <h2 className="text-lg font-bold">Secure your appointment by card</h2>
-        <p className="text-description">
-          A credit or debit card is required to book your appointment.
-        </p>
-        <div className="flex flex-col gap-4">
-          <TextInput
-            label="Card information"
-            {...register("cardNumber", { required: "Card number is required" })}
-            placeholder="1234 1234 1234 1234"
-            error={errors.cardNumber?.message?.toString()}
-          />
-          <div className="flex gap-4 w-full justify-between">
+    <>
+      <form
+        id="payment-form"
+        onSubmit={handleSubmit(onSubmit)}
+        className="bg-white rounded-xl border border-gray-30 p-4 md:py-12 md:px-15 flex flex-col gap-6 w-full"
+      >
+        <div className="flex flex-col gap-6">
+          <h2 className="text-lg font-bold">Secure your appointment by card</h2>
+          <p className="text-description">
+            A credit or debit card is required to book your appointment.
+          </p>
+          <div className="flex flex-col gap-2">
             <TextInput
-              showLabel={false}
-              label="Expiry date"
-              {...register("expiryDate", {
-                required: "Expiry date is required",
+              label="Card information"
+              {...register("cardNumber", {
+                required: "Card number is required",
               })}
-              placeholder="MM/YY"
-              error={errors.expiryDate?.message?.toString()}
+              placeholder="1234 1234 1234 1234"
+              error={errors.cardNumber?.message?.toString()}
             />
-            <TextInput
-              showLabel={false}
-              label="CVV"
-              {...register("cvv", { required: "CVV is required" })}
-              placeholder="CVV"
-              error={errors.cvv?.message?.toString()}
+            <div className="flex gap-1 md:gap-4 w-full justify-start">
+              <div className="max-w-1/2 md:w-full">
+                <TextInput
+                  showLabel={false}
+                  label="Expiry date"
+                  {...register("expiryDate", {
+                    required: "Expiry date is required",
+                  })}
+                  placeholder="MM/YY"
+                  error={errors.expiryDate?.message?.toString()}
+                />
+              </div>
+              <div className="max-w-1/2 md:w-full">
+                <TextInput
+                  showLabel={false}
+                  label="CVV"
+                  {...register("cvv", { required: "CVV is required" })}
+                  placeholder="CVV"
+                  error={errors.cvv?.message?.toString()}
+                />
+              </div>
+            </div>
+          </div>
+          <TextInput
+            showLabel={false}
+            label="Billing zip code"
+            {...register("billingZipCode", {
+              required: "Billing zip code is required",
+            })}
+            placeholder="Billing zip code"
+            error={errors.billingZipCode?.message?.toString()}
+          />
+          <div className="flex items-start gap-2 relative">
+            <input
+              type="checkbox"
+              className="mt-1"
+              id="cancelationPolicy"
+              {...register("cancelationPolicy", {
+                required: "Please agree to the cancelation policy",
+              })}
             />
+            <label
+              className="text-description text-sm"
+              htmlFor="cancelationPolicy"
+            >
+              We ask that you please reschedule or cancel at least 24 hours
+              before the beginning of your appointment or you may be charged a
+              cancellation fee of $50. In the event of emergency, contact us
+              directly. Your card will held in case of late cancellation and for
+              future purchases. It will not be charged now.
+            </label>
+            {errors?.cancelationPolicy?.message && (
+              <p className="text-red-600 text-sm text-right absolute -bottom-4 left-0">
+                {errors.cancelationPolicy.message.toString()}
+              </p>
+            )}
           </div>
         </div>
-        <TextInput
-          showLabel={false}
-          label="Billing zip code"
-          {...register("billingZipCode", {
-            required: "Billing zip code is required",
-          })}
-          placeholder="Billing zip code"
-          error={errors.billingZipCode?.message?.toString()}
-        />
-        <div className="flex items-start gap-2 relative">
-          <input
-            type="checkbox"
-            className="mt-1"
-            id="cancelationPolicy"
-            {...register("cancelationPolicy", {
-              required: "Please agree to the cancelation policy",
-            })}
-          />
-          <label
-            className="text-description text-sm"
-            htmlFor="cancelationPolicy"
-          >
-            We ask that you please reschedule or cancel at least 24 hours before
-            the beginning of your appointment or you may be charged a
-            cancellation fee of $50. In the event of emergency, contact us
-            directly. Your card will held in case of late cancellation and for
-            future purchases. It will not be charged now.
-          </label>
-          {errors?.cancelationPolicy?.message && (
-            <p className="text-red-600 text-sm text-right absolute -bottom-4 left-0">
-              {errors.cancelationPolicy.message.toString()}
-            </p>
-          )}
+        <hr className="border-gray-30" />
+        <div className="w-full flex flex-col gap-6">
+          <Button type="submit" label="Book appointment" fullWidth />
+          <p className="text-description text-sm">
+            By creating this appointment, you acknowledge you will receive
+            automated transactional messages from this merchant.
+          </p>
         </div>
-      </div>
-      <hr className="border-gray-30" />
-      <div className="w-full">
-        <Button type="submit" label="Book appointment" fullWidth />
-      </div>
+      </form>
       <div className="hidden md:block">
         <BottomBar>
-          <div className="w-full flex justify-end">
-            <Button type="submit" label="Continue" />
-          </div>
+          <Button type="submit" form="payment-form" label="Continue" />
         </BottomBar>
       </div>
-    </form>
+    </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,7 @@
   
   --color-gray-20: #f5f5f5;
   --color-gray-30: #E3E3E8;
+  --color-gray-40: ##C8C8D0;
   --color-gray-50: #AEAEB7;
   --color-violet-90: #8A1D96;
   

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,20 +5,24 @@ import { ButtonHTMLAttributes } from "react";
 type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   label: string;
   variant?: "primary";
+  fullWidth?: boolean;
 };
 
 export const Button = ({
   label,
   variant = "primary",
+  fullWidth = false,
   ...props
 }: ButtonProps) => {
   return (
     <button
       {...props}
       className={clsx(
-        "bg-violet-90 py-4 px-9 rounded-2xl border-1.5 w-full md:w-fit font-semibold text-base cursor-pointer",
+        "bg-violet-90 py-4 px-9 rounded-2xl border-1.5 font-semibold text-base cursor-pointer",
         {
           "bg-violet-90 text-white": variant === "primary",
+          "w-full": fullWidth,
+          "w-full md:w-fit": !fullWidth,
         }
       )}
     >

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -4,20 +4,27 @@ import { InputHTMLAttributes } from "react";
 
 type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   label: string;
+  showLabel?: boolean;
   error?: string;
   className?: never;
 };
 
 export const TextInput = ({
   label,
+  showLabel = true,
   type,
   placeholder,
   error,
   ...props
 }: InputProps) => {
   return (
-    <div className="flex flex-col gap-1.5 pb-2 relative">
-      <label className="text-description" htmlFor={label}>
+    <div className="flex flex-col gap-1.5 pb-2 relative w-full">
+      <label
+        className={clsx("text-description", {
+          "sr-only": !showLabel,
+        })}
+        htmlFor={label}
+      >
         {label}
       </label>
       <input


### PR DESCRIPTION
## What
- Adds the `payment` page and form
- Updates the `Button` styles to accept a `fullWidth` prop
- Updates the `TextInput` component styles to hide the label. It's still required; however is visible to screen readers only (`sr-only` class name)

## How it looks
### Desktop
<img width="1726" height="1039" alt="image" src="https://github.com/user-attachments/assets/9cef70fe-a292-4b58-a277-cf74597c97ff" />

### Mobile
<img width="415" height="901" alt="image" src="https://github.com/user-attachments/assets/272e726f-7883-485c-a838-2d4788386daf" />

<img width="415" height="816" alt="image" src="https://github.com/user-attachments/assets/c42e78d3-63a2-475b-be90-58031a8c67c7" />


## Assumptions and trade-offs
- Due to time constraints, I wasn't able to extract the `Checkbox` into a reusable component or fully match its styling with the Figma designs.
- The CVV and expiry date inputs are slightly misaligned in smaller viewports, which affects the layout responsiveness. This would require a proper responsive fix in a follow-up iteration.
- Validation error messages in the payment form inputs currently break the layout due to the spacing between the fields. I decided not to spend more time on this and prioritized completing the payment page instead.
- The text visualization inside the credit card info inputs (e.g., showing card type or masked formatting) was not implemented.
- I assumed that the bottom bar with the `Continue` button is intentionally included in the design, even though it duplicates the functionality of the `Book appointment` button. In a real project, I would clarify this with the designer and product manager to avoid potential UX redundancy.
